### PR TITLE
fix for duplicate "monitored" metrics

### DIFF
--- a/monit_exporter.go
+++ b/monit_exporter.go
@@ -184,6 +184,7 @@ func (e *Exporter) scrape() error {
 func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 	e.mutex.Lock() // Protect metrics from concurrent collects.
 	defer e.mutex.Unlock()
+	e.checkStatus.Reset()
 	e.scrape()
 	e.up.Collect(ch)
 	e.checkStatus.Collect(ch)


### PR DESCRIPTION
Fix the situation, where we ended up with all possible "monitored" labels for services after switching off monit checks.