### PR TITLE
Update monit_exporter.go

### DIFF
--- a/monit_exporter.go
+++ b/monit_exporter.go
@@ -207,7 +207,7 @@ func main() {
 	prometheus.MustRegister(exporter)
 
 	log.Printf("Starting monit_exporter: %s", config.listen_address)
-	http.Handle(config.metrics_path, promehttp.Handler())
+	http.Handle(config.metrics_path, promhttp.Handler())
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(`<html>
             <head><title>Monit Exporter</title></head>

--- a/monit_exporter.go
+++ b/monit_exporter.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/log"
 	"github.com/spf13/viper"
 	"golang.org/x/net/html/charset"
@@ -206,7 +207,7 @@ func main() {
 	prometheus.MustRegister(exporter)
 
 	log.Printf("Starting monit_exporter: %s", config.listen_address)
-	http.Handle(config.metrics_path, prometheus.Handler())
+	http.Handle(config.metrics_path, promehttp.Handler())
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(`<html>
             <head><title>Monit Exporter</title></head>


### PR DESCRIPTION
Update monit_exporter.go to use promhttp.Handler() instead of deprecated prometheus.Handler()